### PR TITLE
Fix OS X 10.9 compiling issues

### DIFF
--- a/src/Husky/ThreadManager.hpp
+++ b/src/Husky/ThreadManager.hpp
@@ -12,7 +12,7 @@ namespace Husky
     class ThreadManager
     {
         private:
-            typedef int HANDLE;
+            typedef pthread_t HANDLE;
             typedef void *(* PThreadFunc)(void* param);
         public:
             ThreadManager(){;}
@@ -25,7 +25,7 @@ namespace Husky
                 _handles.clear();
             }
 
-            HANDLE CreateThread( PThreadFunc pFunc,void *pPara)
+            int CreateThread( PThreadFunc pFunc,void *pPara)
             {	
                 pthread_t pt;
                 int nErrorCode = pthread_create(&pt,NULL,pFunc,pPara);

--- a/test/unittest/TKeywordExtractor.cpp
+++ b/test/unittest/TKeywordExtractor.cpp
@@ -29,7 +29,7 @@ TEST(KeywordExtractorTest, Test2)
 TEST(KeywordExtractorTest, Test3)
 {
     ifstream ifs("../test/testdata/weicheng.utf8");
-    ASSERT_TRUE(ifs);
+    ASSERT_TRUE(!!ifs);
     string str((istreambuf_iterator<char>(ifs)), (istreambuf_iterator<char>()));
     KeywordExtractor extractor("../dict/jieba.dict.utf8", "../dict/idf.utf8");
     const char* res[] = {"小姐", "孙小姐", "方鸿渐", "自己", "没有"};
@@ -42,7 +42,7 @@ TEST(KeywordExtractorTest, Test3)
 TEST(KeywordExtractorTest, Test4)
 {
     ifstream ifs("../test/testdata/weicheng.utf8");
-    ASSERT_TRUE(ifs);
+    ASSERT_TRUE(!!ifs);
     string str((istreambuf_iterator<char>(ifs)), (istreambuf_iterator<char>()));
     KeywordExtractor extractor("../dict/jieba.dict.utf8", "../dict/idf.utf8");
     //const char* res[] = {"小姐", "孙小姐", "方鸿渐", "自己", "没有"};

--- a/test/unittest/gtest-1.6.0/include/gtest/internal/gtest-port.h
+++ b/test/unittest/gtest-1.6.0/include/gtest/internal/gtest-port.h
@@ -496,7 +496,20 @@
 #   undef _TR1_FUNCTIONAL  // Allows the user to #include
                         // <tr1/functional> if he chooses to.
 #  else
+#  if defined (__cplusplus) && __cplusplus > 199711L
+#   include <tuple>
+namespace std {
+    namespace tr1 {
+        using std::tuple;
+        using std::tuple_element;
+        using std::get;
+        using std::tuple_size;
+        using std::make_tuple;
+    }
+}
+#  else
 #   include <tr1/tuple>  // NOLINT
+#  endif
 #  endif  // !GTEST_HAS_RTTI && GTEST_GCC_VER_ < 40302
 
 # else


### PR DESCRIPTION
OS X 10.9 默認帶的編譯器是 clang + llvm，在編譯 cppjieba 時會遇到一些錯誤。

其中 gtest 的錯誤是參考 OpenCV 的類似 issue ([OpenCV - Bug #2264: Compiling on clang/C++11, tr1/tuple doesn't exist](http://code.opencv.org/issues/2264)) 進行修正
