### PR TITLE
避免log fatal

### DIFF
--- a/src/DictTrie.hpp
+++ b/src/DictTrie.hpp
@@ -104,6 +104,8 @@ class DictTrie {
       DictUnit node_info;
       vector<string> buf;
       for (; getline(ifs, line); lineno++) {
+        if (line.size() == 0)
+          continue;
         buf.clear();
         split(line, buf, " ");
         if (buf.size() < 1) {


### PR DESCRIPTION
避免当自定义字典当中如果有空白行时，会log fatal。  
也就是说当自定义字典有空白行，不会退出。

还有基于您的项目成果，我个人开始了一个为开源数据库PostgreSQL支持jieba分词的开源插件项目https://github.com/jaiminpan/pg_jieba。  
这样可以使PostgreSQL可以直接支持jieba分词，之后也会持续关注和支持新的功能。  
十分感谢您的劳动成果。望有机会多交流。