### PR TITLE
增加 LookupTag 函数来对单个的 token 进行 tag 查询

### DIFF
--- a/include/cppjieba/Jieba.hpp
+++ b/include/cppjieba/Jieba.hpp
@@ -62,6 +62,9 @@ class Jieba {
   void Tag(const string& sentence, vector<pair<string, string> >& words) const {
     mix_seg_.Tag(sentence, words);
   }
+  string LookupTag(const string &str) const {
+    return mix_seg_.LookupTag(str);
+  }
   bool InsertUserWord(const string& word, const string& tag = UNKNOWN_TAG) {
     return dict_trie_.InsertUserWord(word, tag);
   }

--- a/include/cppjieba/MixSegment.hpp
+++ b/include/cppjieba/MixSegment.hpp
@@ -93,6 +93,10 @@ class MixSegment: public SegmentTagged {
     return tagger_.Tag(src, res, *this);
   }
 
+  string LookupTag(const string &str) const {
+    return tagger_.LookupTag(str, *this);
+  }
+
  private:
   MPSegment mpSeg_;
   HMMSegment hmmSeg_;

--- a/include/cppjieba/PosTagger.hpp
+++ b/include/cppjieba/PosTagger.hpp
@@ -23,24 +23,29 @@ class PosTagger {
     vector<string> CutRes;
     segment.Cut(src, CutRes);
 
+    for (vector<string>::iterator itr = CutRes.begin(); itr != CutRes.end(); ++itr) {
+      res.push_back(make_pair(*itr, LookupTag(*itr, segment)));
+    }
+    return !res.empty();
+  }
+
+  string LookupTag(const string &str, const SegmentTagged& segment) const {
     const DictUnit *tmp = NULL;
     RuneStrArray runes;
     const DictTrie * dict = segment.GetDictTrie();
     assert(dict != NULL);
-    for (vector<string>::iterator itr = CutRes.begin(); itr != CutRes.end(); ++itr) {
-      if (!DecodeRunesInString(*itr, runes)) {
+      if (!DecodeRunesInString(str, runes)) {
         XLOG(ERROR) << "Decode failed.";
-        return false;
+        return POS_X;
       }
       tmp = dict->Find(runes.begin(), runes.end());
       if (tmp == NULL || tmp->tag.empty()) {
-        res.push_back(make_pair(*itr, SpecialRule(runes)));
+        return SpecialRule(runes);
       } else {
-        res.push_back(make_pair(*itr, tmp->tag));
+        return tmp->tag;
       }
-    }
-    return !res.empty();
   }
+
  private:
   const char* SpecialRule(const RuneStrArray& unicode) const {
     size_t m = 0;

--- a/test/demo.cpp
+++ b/test/demo.cpp
@@ -51,6 +51,13 @@ int main(int argc, char** argv) {
   jieba.CutForSearch(s, jiebawords, true);
   cout << jiebawords << endl;
 
+  cout << "[demo] Lookup Tag for Single Token" << endl;
+  vector<pair<string, string> > LookupTagres = {{"拖拉机", ""}, {"CEO", ""}, {".",""}};
+  LookupTagres[0].second = jieba.LookupTag(LookupTagres[0].first);
+  LookupTagres[1].second = jieba.LookupTag(LookupTagres[1].first);
+  LookupTagres[2].second = jieba.LookupTag(LookupTagres[2].first);
+  cout << LookupTagres << endl;;
+
   cout << "[demo] Tagging" << endl;
   vector<pair<string, string> > tagres;
   s = "我是拖拉机学院手扶拖拉机专业的。不用多久，我就会升职加薪，当上CEO，走上人生巅峰。";

--- a/test/demo.cpp
+++ b/test/demo.cpp
@@ -52,11 +52,15 @@ int main(int argc, char** argv) {
   cout << jiebawords << endl;
 
   cout << "[demo] Lookup Tag for Single Token" << endl;
-  vector<pair<string, string> > LookupTagres = {{"拖拉机", ""}, {"CEO", ""}, {".",""}};
-  LookupTagres[0].second = jieba.LookupTag(LookupTagres[0].first);
-  LookupTagres[1].second = jieba.LookupTag(LookupTagres[1].first);
-  LookupTagres[2].second = jieba.LookupTag(LookupTagres[2].first);
-  cout << LookupTagres << endl;;
+  const int DemoTokenMaxLen = 32;
+  char DemoTokens[][DemoTokenMaxLen] = {"拖拉机", "CEO", "123", "。"};
+  vector<pair<string, string> > LookupTagres(sizeof(DemoTokens) / DemoTokenMaxLen);
+  vector<pair<string, string> >::iterator it;
+  for (it = LookupTagres.begin(); it != LookupTagres.end(); it++) {
+	it->first = DemoTokens[it - LookupTagres.begin()];
+	it->second = jieba.LookupTag(it->first);
+  }
+  cout << LookupTagres << endl;
 
   cout << "[demo] Tagging" << endl;
   vector<pair<string, string> > tagres;


### PR DESCRIPTION
由于 CutForSearch 没有提供 Tag 功能，如果想要分词以后既得到 offset 信息，又得到 token 的 tag 信息，当前的 API 粒度稍大难以做到，建议把 tag 函数的粒度降低，提供得到单个 token tag 的 API。