### PR TITLE
减少Visual Studio编译器警告

### DIFF
--- a/include/cppjieba/FullSegment.hpp
+++ b/include/cppjieba/FullSegment.hpp
@@ -48,17 +48,17 @@ class FullSegment: public SegmentBase {
   void Cut(RuneStrArray::const_iterator begin, 
         RuneStrArray::const_iterator end, 
         vector<WordRange>& res) const {
-    //resut of searching in trie tree
+    // resut of searching in trie tree
     LocalVector<pair<size_t, const DictUnit*> > tRes;
 
-    //max index of res's words
-    int maxIdx = 0;
+    // max index of res's words
+    size_t maxIdx = 0;
 
     // always equals to (uItr - begin)
-    int uIdx = 0;
+    size_t uIdx = 0;
 
-    //tmp variables
-    int wordLen = 0;
+    // tmp variables
+    size_t wordLen = 0;
     assert(dictTrie_);
     vector<struct Dag> dags;
     dictTrie_->Find(begin, end, dags);

--- a/include/cppjieba/Unicode.hpp
+++ b/include/cppjieba/Unicode.hpp
@@ -142,7 +142,7 @@ inline RuneStrLite DecodeRuneInString(const char* str, size_t len) {
 inline bool DecodeRunesInString(const char* s, size_t len, RuneStrArray& runes) {
   runes.clear();
   runes.reserve(len / 2);
-  for (size_t i = 0, j = 0; i < len;) {
+  for (uint32_t i = 0, j = 0; i < len;) {
     RuneStrLite rp = DecodeRuneInString(s + i, len - i);
     if (rp.len == 0) {
       runes.clear();


### PR DESCRIPTION
修改了HMMSegment.hpp和Unicode.hpp中的一些变量类型，减少Visual Studio下的编译警告。
还有两个编译警告，看了下代码，还是没修改：
warning C4267: “=”: 从“size_t”转换到“int”，可能丢失数据
```
          if (tmp > weight[now]) {
            weight[now] = tmp;
            path[now] = preY;
          }
```
warning C4267: “初始化”: 从“size_t”转换到“int”，可能丢失数据
```
    for (int x = X -1 ; x >= 0; x--) {
      status[x] = stat;
      stat = path[x + stat*X];
    }
```