### PR TITLE
let MPSegment using same basic ruls as HMMSegment

### DIFF
--- a/include/cppjieba/HMMSegment.hpp
+++ b/include/cppjieba/HMMSegment.hpp
@@ -44,6 +44,10 @@ class HMMSegment: public SegmentBase {
     GetWordsFromWordRanges(sentence, wrs, words);
   }
   void Cut(RuneStrArray::const_iterator begin, RuneStrArray::const_iterator end, vector<WordRange>& res) const {
+    BasicCut(begin,end,res);
+  }
+ private:
+  void BasicCut(RuneStrArray::const_iterator begin, RuneStrArray::const_iterator end, vector<WordRange>& res) const {
     RuneStrArray::const_iterator left = begin;
     RuneStrArray::const_iterator right = begin;
     while (right != end) {
@@ -73,44 +77,7 @@ class HMMSegment: public SegmentBase {
     if (left != right) {
       InternalCut(left, right, res);
     }
-  }
- private:
-  // sequential letters rule
-  RuneStrArray::const_iterator SequentialLetterRule(RuneStrArray::const_iterator begin, RuneStrArray::const_iterator end) const {
-    Rune x = begin->rune;
-    if (('a' <= x && x <= 'z') || ('A' <= x && x <= 'Z')) {
-      begin ++;
-    } else {
-      return begin;
-    }
-    while (begin != end) {
-      x = begin->rune;
-      if (('a' <= x && x <= 'z') || ('A' <= x && x <= 'Z') || ('0' <= x && x <= '9')) {
-        begin ++;
-      } else {
-        break;
-      }
-    }
-    return begin;
-  }
-  //
-  RuneStrArray::const_iterator NumbersRule(RuneStrArray::const_iterator begin, RuneStrArray::const_iterator end) const {
-    Rune x = begin->rune;
-    if ('0' <= x && x <= '9') {
-      begin ++;
-    } else {
-      return begin;
-    }
-    while (begin != end) {
-      x = begin->rune;
-      if ( ('0' <= x && x <= '9') || x == '.') {
-        begin++;
-      } else {
-        break;
-      }
-    }
-    return begin;
-  }
+}
   void InternalCut(RuneStrArray::const_iterator begin, RuneStrArray::const_iterator end, vector<WordRange>& res) const {
     vector<size_t> status;
     Viterbi(begin, end, status);

--- a/include/cppjieba/SegmentBase.hpp
+++ b/include/cppjieba/SegmentBase.hpp
@@ -4,7 +4,7 @@
 #include "limonp/Logging.hpp"
 #include "PreFilter.hpp"
 #include <cassert>
-
+// #include "Unicode.hpp"
 
 namespace cppjieba {
 
@@ -39,6 +39,46 @@ class SegmentBase {
   }
  protected:
   unordered_set<Rune> symbols_;
+ 
+  // sequential letters rule
+RuneStrArray::const_iterator SequentialLetterRule(RuneStrArray::const_iterator begin, RuneStrArray::const_iterator end) const {
+  Rune x = begin->rune;
+  if (('a' <= x && x <= 'z') || ('A' <= x && x <= 'Z')) {
+    begin ++;
+  } else {
+    return begin;
+  }
+  while (begin != end) {
+    x = begin->rune;
+    if (('a' <= x && x <= 'z') || ('A' <= x && x <= 'Z') || ('0' <= x && x <= '9')) {
+      begin ++;
+    } else {
+      break;
+    }
+  }
+  return begin;
+}
+//
+RuneStrArray::const_iterator NumbersRule(RuneStrArray::const_iterator begin, RuneStrArray::const_iterator end) const {
+  Rune x = begin->rune;
+  if ('0' <= x && x <= '9') {
+    begin ++;
+  } else {
+    return begin;
+  }
+  while (begin != end) {
+    x = begin->rune;
+    if ( ('0' <= x && x <= '9') || x == '.') {
+      begin++;
+    } else {
+      break;
+    }
+  }
+  return begin;
+}
+// private:
+//   virtual void InternalCut(RuneStrArray::const_iterator begin, RuneStrArray::const_iterator end, vector<WordRange>& res,size_t max_word_len) const = 0;
+
 }; // class SegmentBase
 
 } // cppjieba


### PR DESCRIPTION
遗留问题:
jieba用正则筛选哪些应该被cut的部分
cppjieba用字符范围过滤不应被cut的部分
导致符号数字和中英混合的时候结果和jieba不同

详见：
https://github.com/bung87/cppjieba-py/blob/master/performace_test/consistency.py
注释的部分无论是否使用hmm都不会通过。

CI 检查失败了，修改后我的测试通过了更多，不知为何cpp测试反而失败了，我加载的最新jieba的词典，先这样吧。
