### PR TITLE
avoid implicit namespaces

### DIFF
--- a/include/cppjieba/KeywordExtractor.hpp
+++ b/include/cppjieba/KeywordExtractor.hpp
@@ -1,37 +1,35 @@
 #ifndef CPPJIEBA_KEYWORD_EXTRACTOR_H
 #define CPPJIEBA_KEYWORD_EXTRACTOR_H
 
-#include <cmath>
-#include <set>
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
 #include "MixSegment.hpp"
 
 namespace cppjieba {
-
-using namespace limonp;
-using namespace std;
 
 /*utf8*/
 class KeywordExtractor {
  public:
   struct Word {
-    string word;
-    vector<size_t> offsets;
+    std::string word;
+    std::vector<size_t> offsets;
     double weight;
   }; // struct Word
 
-  KeywordExtractor(const string& dictPath, 
-        const string& hmmFilePath, 
-        const string& idfPath, 
-        const string& stopWordPath, 
-        const string& userDict = "") 
+  KeywordExtractor(const std::string& dictPath, 
+        const std::string& hmmFilePath, 
+        const std::string& idfPath, 
+        const std::string& stopWordPath, 
+        const std::string& userDict = "") 
     : segment_(dictPath, hmmFilePath, userDict) {
     LoadIdfDict(idfPath);
     LoadStopWordDict(stopWordPath);
   }
   KeywordExtractor(const DictTrie* dictTrie, 
         const HMMModel* model,
-        const string& idfPath, 
-        const string& stopWordPath) 
+        const std::string& idfPath, 
+        const std::string& stopWordPath) 
     : segment_(dictTrie, model) {
     LoadIdfDict(idfPath);
     LoadStopWordDict(stopWordPath);
@@ -39,27 +37,27 @@ class KeywordExtractor {
   ~KeywordExtractor() {
   }
 
-  void Extract(const string& sentence, vector<string>& keywords, size_t topN) const {
-    vector<Word> topWords;
+  void Extract(const std::string& sentence, std::vector<std::string>& keywords, size_t topN) const {
+    std::vector<Word> topWords;
     Extract(sentence, topWords, topN);
     for (size_t i = 0; i < topWords.size(); i++) {
       keywords.push_back(topWords[i].word);
     }
   }
 
-  void Extract(const string& sentence, vector<pair<string, double> >& keywords, size_t topN) const {
-    vector<Word> topWords;
+  void Extract(const std::string& sentence, std::vector<pair<std::string, double> >& keywords, size_t topN) const {
+    std::vector<Word> topWords;
     Extract(sentence, topWords, topN);
     for (size_t i = 0; i < topWords.size(); i++) {
-      keywords.push_back(pair<string, double>(topWords[i].word, topWords[i].weight));
+      keywords.push_back(pair<std::string, double>(topWords[i].word, topWords[i].weight));
     }
   }
 
-  void Extract(const string& sentence, vector<Word>& keywords, size_t topN) const {
-    vector<string> words;
+  void Extract(const std::string& sentence, std::vector<Word>& keywords, size_t topN) const {
+    std::vector<std::string> words;
     segment_.Cut(sentence, words);
 
-    map<string, Word> wordmap;
+    std::map<std::string, Word> wordmap;
     size_t offset = 0;
     for (size_t i = 0; i < words.size(); ++i) {
       size_t t = offset;
@@ -77,8 +75,8 @@ class KeywordExtractor {
 
     keywords.clear();
     keywords.reserve(wordmap.size());
-    for (map<string, Word>::iterator itr = wordmap.begin(); itr != wordmap.end(); ++itr) {
-      unordered_map<string, double>::const_iterator cit = idfMap_.find(itr->first);
+    for (std::map<std::string, Word>::iterator itr = wordmap.begin(); itr != wordmap.end(); ++itr) {
+      std::unordered_map<std::string, double>::const_iterator cit = idfMap_.find(itr->first);
       if (cit != idfMap_.end()) {
         itr->second.weight *= cit->second;
       } else {
@@ -88,15 +86,15 @@ class KeywordExtractor {
       keywords.push_back(itr->second);
     }
     topN = min(topN, keywords.size());
-    partial_sort(keywords.begin(), keywords.begin() + topN, keywords.end(), Compare);
+    std::partial_sort(keywords.begin(), keywords.begin() + topN, keywords.end(), Compare);
     keywords.resize(topN);
   }
  private:
-  void LoadIdfDict(const string& idfPath) {
-    ifstream ifs(idfPath.c_str());
+  void LoadIdfDict(const std::string& idfPath) {
+    std::ifstream ifs(idfPath.c_str());
     XCHECK(ifs.is_open()) << "open " << idfPath << " failed";
-    string line ;
-    vector<string> buf;
+    std::string line ;
+    std::vector<std::string> buf;
     double idf = 0.0;
     double idfSum = 0.0;
     size_t lineno = 0;
@@ -106,7 +104,7 @@ class KeywordExtractor {
         XLOG(ERROR) << "lineno: " << lineno << " empty. skipped.";
         continue;
       }
-      Split(line, buf, " ");
+      limonp::Split(line, buf, " ");
       if (buf.size() != 2) {
         XLOG(ERROR) << "line: " << line << ", lineno: " << lineno << " empty. skipped.";
         continue;
@@ -121,10 +119,10 @@ class KeywordExtractor {
     idfAverage_ = idfSum / lineno;
     assert(idfAverage_ > 0.0);
   }
-  void LoadStopWordDict(const string& filePath) {
-    ifstream ifs(filePath.c_str());
+  void LoadStopWordDict(const std::string& filePath) {
+    std::ifstream ifs(filePath.c_str());
     XCHECK(ifs.is_open()) << "open " << filePath << " failed";
-    string line ;
+    std::string line ;
     while (getline(ifs, line)) {
       stopWords_.insert(line);
     }
@@ -136,18 +134,16 @@ class KeywordExtractor {
   }
 
   MixSegment segment_;
-  unordered_map<string, double> idfMap_;
+  std::unordered_map<std::string, double> idfMap_;
   double idfAverage_;
 
-  unordered_set<string> stopWords_;
+  std::unordered_set<std::string> stopWords_;
 }; // class KeywordExtractor
 
-inline ostream& operator << (ostream& os, const KeywordExtractor::Word& word) {
+inline std::ostream& operator << (std::ostream& os, const KeywordExtractor::Word& word) {
   return os << "{\"word\": \"" << word.word << "\", \"offset\": " << word.offsets << ", \"weight\": " << word.weight << "}"; 
 }
 
 } // namespace cppjieba
 
 #endif
-
-


### PR DESCRIPTION
This PR fixes the ambigious `partial_sort` in KeywordExtractor.hpp. We also have a definition for it and the compiler is consufed which implementation should be used. To fix it, we can use the `std` namespace explicitly.

Also, use the `std` namespace for the other data structures and include their headers.