### PR TITLE
Fix segmentation for 习总书记

### DIFF
--- a/test/unittest/segments_test.cpp
+++ b/test/unittest/segments_test.cpp
@@ -65,6 +65,14 @@ TEST(MixSegmentTest, Test1) {
     actual = Join(words.begin(), words.end(), "/");
     ASSERT_EQ(actual, expected);
   }
+
+  {
+    sentence = "马克思主义和习总书记新时代中国特色社会主义";
+    expected = "马克思主义/和/习总书记/新/时代/中国/特色/社会主义";
+    segment.Cut(sentence, words);
+    actual = Join(words.begin(), words.end(), "/");
+    ASSERT_EQ(actual, expected);
+  }
 }
 
 TEST(MixSegmentTest, NoUserDict) {


### PR DESCRIPTION
## Summary
- Add `习总书记` to the main dictionary so `和习总书记` no longer merges `和习` as one token.
- Add a MixSegment regression test for `马克思主义和习总书记新时代中国特色社会主义`.

## Notes
- This is a narrower alternative to #224: it changes the main dictionary entry needed for the reported bad split without adding extra user-dictionary overrides for adjacent terms.
- Fixes #223.

## Verification
- `make test` passed locally on 2026-04-23.

## Release assessment
- This is a user-visible dictionary correctness fix. A patch release should be considered after merge, but no cppjieba release has been published from this branch yet.