### PR TITLE
Add regression tests for “了解” segmentation

### DIFF
--- a/test/unittest/jieba_test.cpp
+++ b/test/unittest/jieba_test.cpp
@@ -35,6 +35,10 @@ TEST(JiebaTest, Test0) {
   jieba.CutForSearch("他来到了网易杭研大厦", words);
   result << words;
   ASSERT_EQ("[\"他\", \"来到\", \"了\", \"网易\", \"杭研\", \"大厦\"]", result);
+
+  jieba.Cut("让我去了解一下", words);
+  result << words;
+  ASSERT_EQ("[\"让\", \"我\", \"去\", \"了解\", \"一下\"]", result);
 }
 
 TEST(JiebaTest, Test1) {
@@ -72,6 +76,10 @@ TEST(JiebaTest, Test1) {
   jieba.CutForSearch("他来到了网易杭研大厦", words);
   result << words;
   ASSERT_EQ("[\"他\", \"来到\", \"了\", \"网易\", \"杭研\", \"大厦\"]", result);
+
+  jieba.Cut("让我去了解一下", words);
+  result << words;
+  ASSERT_EQ("[\"让\", \"我\", \"去\", \"了解\", \"一下\"]", result);
 }
 
 TEST(JiebaTest, WordTest) {


### PR DESCRIPTION
有下游用户表示「了解」一词在 jieba 分词启用后会出错。虽事后证明并非 cppjieba 分词库的问题，但为了谨慎起见添加一个 regression test 以防止出现回退。

说明见 https://github.com/TerryTian-tech/OpenCC-Traditional-Chinese-characters-according-to-Chinese-government-standards/releases/tag/Transformer(1.3.2)

cc @TerryTian-tech