### PR TITLE
Update checkout action in CMake workflows

### DIFF
--- a/.github/workflows/cmake-arm64.yml
+++ b/.github/workflows/cmake-arm64.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
             submodules: recursive
 

--- a/.github/workflows/cmake-arm64.yml
+++ b/.github/workflows/cmake-arm64.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
             submodules: recursive
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        # See https://cmake.org/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
         # run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         run: cmake -B ${{github.workspace}}/build -DBUILD_TESTING=ON -DCMAKE_CXX_STANDARD=${{matrix.cpp_version}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
@@ -35,6 +35,6 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         # Execute tests defined by the CMake configuration.  
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        # See https://cmake.org/help/latest/manual/ctest.1.html for more detail
         run: ctest -C ${{env.BUILD_TYPE}} --verbose
       

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         # Execute tests defined by the CMake configuration.  
-        # See https://cmake.org/latest/manual/ctest.1.html for more detail
+        # See https://cmake.org/help/latest/manual/ctest.1.html for more detail
         run: ctest -C ${{env.BUILD_TYPE}} --verbose
       

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
             submodules: recursive
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
             submodules: recursive
 
@@ -46,6 +46,6 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         # Execute tests defined by the CMake configuration.  
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        # See https://cmake.org/latest/manual/ctest.1.html for more detail
         run: ctest -C ${{env.BUILD_TYPE}} --verbose
       


### PR DESCRIPTION
## Summary
- update CMake workflows from `actions/checkout@v2` to `actions/checkout@v6`
- preserve the existing OS and C++ standard matrices

## Context
- Existing runner matrix already covers explicit baseline runners plus current `*-latest` labels.

## Testing
- Not run locally; workflow-only change.