### PR TITLE
Add Bazel build support

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,18 @@
+name: Bazel
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Test
+        run: npx --yes @bazel/bazelisk test //:bazel_smoke_test

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "limonp",
+    hdrs = glob(["deps/limonp/include/limonp/**/*.hpp"]),
+    includes = ["deps/limonp/include"],
+)
+
+filegroup(
+    name = "dict",
+    srcs = glob(["dict/**"]),
+)
+
+cc_library(
+    name = "cppjieba",
+    hdrs = glob(["include/cppjieba/**/*.hpp"]),
+    includes = ["include"],
+    deps = [":limonp"],
+)
+
+cc_test(
+    name = "bazel_smoke_test",
+    srcs = ["test/bazel_smoke_test.cpp"],
+    data = [":dict"],
+    deps = [":cppjieba"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "cppjieba",
+    version = "5.6.7",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/test/bazel_smoke_test.cpp
+++ b/test/bazel_smoke_test.cpp
@@ -1,0 +1,38 @@
+#include "cppjieba/Jieba.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string RunfilePath(const std::string& relative_path) {
+  const char* test_srcdir = std::getenv("TEST_SRCDIR");
+  const char* test_workspace = std::getenv("TEST_WORKSPACE");
+  if (test_srcdir == NULL || test_workspace == NULL) {
+    return relative_path;
+  }
+
+  return std::string(test_srcdir) + "/" + test_workspace + "/" + relative_path;
+}
+
+}  // namespace
+
+int main() {
+  cppjieba::Jieba jieba(
+      RunfilePath("dict/jieba.dict.utf8"),
+      RunfilePath("dict/hmm_model.utf8"),
+      RunfilePath("dict/user.dict.utf8"),
+      RunfilePath("dict/idf.utf8"),
+      RunfilePath("dict/stop_words.utf8"));
+
+  std::vector<std::string> words;
+  jieba.Cut("南京市长江大桥", words);
+  if (words.empty()) {
+    std::cerr << "Expected cppjieba to segment the smoke-test sentence.\n";
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add Bzlmod metadata and public Bazel targets for `cppjieba`, vendored `limonp`, and dictionary files
- add a small Bazel smoke test that constructs `cppjieba::Jieba` with runfile dictionary paths
- add a Bazel GitHub Actions workflow to keep the new build path covered

## Validation
- `npx --yes @bazel/bazelisk test --cache_test_results=no //:bazel_smoke_test`

Closes #233