### PR TITLE
[codex] Update limonp dependency

### DIFF
--- a/include/cppjieba/Unicode.hpp
+++ b/include/cppjieba/Unicode.hpp
@@ -1,6 +1,7 @@
 #ifndef CPPJIEBA_UNICODE_H
 #define CPPJIEBA_UNICODE_H
 
+#include <cassert>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string>


### PR DESCRIPTION
## Summary

- update the bundled `deps/limonp` submodule from `v1.0.2` (`9d74077`) to `4065c5f`, which includes the `LocalVector` modernization from yanyiwu/limonp#44
- add an explicit `<cassert>` include in `Unicode.hpp`

## Why

The modernized `LocalVector.hpp` no longer includes `<assert.h>` as an implementation detail. `Unicode.hpp` uses `assert` directly, so updating the submodule exposed an existing indirect-include dependency and caused the unit-test build to fail. Including `<cassert>` at the actual use site makes the dependency explicit.

## Validation

- `cmake -S . -B /tmp/cppjieba-limonp-build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/cppjieba-limonp-build --parallel 2`
- `ctest --test-dir /tmp/cppjieba-limonp-build --output-on-failure`

Result: 2/2 CTest tests passed.