### PR TITLE
Fix missing self-contained header includes

### DIFF
--- a/include/cppjieba/DictTrie.hpp
+++ b/include/cppjieba/DictTrie.hpp
@@ -19,9 +19,6 @@
 #include "Trie.hpp"
 
 namespace cppjieba {
-
-const double MIN_DOUBLE = -3.14e+100;
-const double MAX_DOUBLE = 3.14e+100;
 const size_t DICT_COLUMN_NUM = 3;
 const char* const UNKNOWN_TAG = "";
 

--- a/include/cppjieba/SegmentTagged.hpp
+++ b/include/cppjieba/SegmentTagged.hpp
@@ -5,6 +5,8 @@
 
 namespace cppjieba {
 
+class DictTrie;
+
 class SegmentTagged : public SegmentBase{
  public:
   SegmentTagged() {

--- a/include/cppjieba/Utils.hpp
+++ b/include/cppjieba/Utils.hpp
@@ -56,6 +56,9 @@ enum {
   LL_FATAL = 4,
 };
 
+const double MIN_DOUBLE = -3.14e+100;
+const double MAX_DOUBLE = 3.14e+100;
+
 static const char* const LOG_LEVEL_ARRAY[] = {"DEBUG", "INFO", "WARN", "ERROR", "FATAL"};
 static const char* const LOG_TIME_FORMAT = "%Y-%m-%d %H:%M:%S";
 


### PR DESCRIPTION
Some stricter build environments require every public header to be self-contained. In other words, including and compiling any public header on its own must not depend on another header having happened to be included first.

`SegmentTagged.hpp` previously worked under the common include paths used in this repository, but it did not declare `DictTrie` when compiled in isolation. Similarly, `HMMSegment.hpp` indirectly depended on `DictTrie.hpp` for `MIN_DOUBLE`.

These implicit include dependencies can become real build failures when using stricter header parsing, modular builds, PCH/IWYU workflows, or simply a different include order. Add the missing direct includes so the affected headers are self-contained.